### PR TITLE
Fix print ImportError pygame

### DIFF
--- a/test_bloom.py
+++ b/test_bloom.py
@@ -26,8 +26,8 @@ SOFTWARE.
 try:
     import pygame
 except ImportError:
-    print("\n<numpy> library is missing on your system."
-          "\nTry: \n   C:\\pip install numpy on a window command prompt.")
+    print("\n<pygame> library is missing on your system."
+          "\nTry: \n   C:\\pip install pygame on a window command prompt.")
     raise SystemExit
 
 try:


### PR DESCRIPTION
Just a small error in the test_bloom.py file, when the import pygame threw an ImportError, the printed text mentioned numpy instead of pygame.